### PR TITLE
Accuratize unix/fd-send-recv deps

### DIFF
--- a/packages/unix-sys-stat/unix-sys-stat.0.1.0/opam
+++ b/packages/unix-sys-stat/unix-sys-stat.0.1.0/opam
@@ -12,5 +12,5 @@ build: [
   [make "install"]
 ]
 remove: [[make "uninstall"]]
-depends: ["ocamlfind"]
-depopts: ["ctypes"]
+depends: ["ocamlfind" "base-unix"]
+depopts: [("ctypes" & "fd-send-recv")]

--- a/packages/unix-unistd/unix-unistd.0.1.0/opam
+++ b/packages/unix-unistd/unix-unistd.0.1.0/opam
@@ -12,5 +12,5 @@ build: [
   [make "install"]
 ]
 remove: [[make "uninstall"]]
-depends: ["ocamlfind"]
-depopts: ["ctypes"]
+depends: ["ocamlfind" "base-unix"]
+depopts: [("ctypes" & "fd-send-recv")]


### PR DESCRIPTION
This is actually accurate and makes the required change clear:

`"ctypes" | ("ctypes" & "base-unix" & "fd-send-recv")` should be the optional dependency eventually. To get there, we need better factorization of these libs, perhaps a subsignature of `Unix` for exceptions, **and** portable ctypes struct sizes.
