### PR TITLE
Add a compiler description for 4.02.0+modular-implicits-ber.

### DIFF
--- a/compilers/4.02.0+modular-implicits-ber.comp
+++ b/compilers/4.02.0+modular-implicits-ber.comp
@@ -1,0 +1,13 @@
+opam-version: "1"
+version: "4.02.0"
+src: "https://github.com/yallop/ocaml/archive/modular-implicits-ber.tar.gz"
+build: [
+  ["./configure" "-prefix" "%{prefix}%"]
+  ["%{make}%" "world" "opt" "opt.opt"]
+  ["%{make}%" "install"]
+  ["%{make}%" "-C" "metalib" "all" "install"]
+]
+packages: ["base-unix" "base-bigarray" "base-threads" "base-metaocaml-ocamlfind"]
+env: [
+  [CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]
+]

--- a/compilers/4.02.0+modular-implicits-ber.descr
+++ b/compilers/4.02.0+modular-implicits-ber.descr
@@ -1,0 +1,1 @@
+OCaml 4.02, with support for modular implicits and staging.


### PR DESCRIPTION
Add a description for a 4.02 compiler enhanced with both modular implicits and BER MetaOCaml's staging constructs.