### PR TITLE
Update the opam file for unix-dirent

### DIFF
--- a/packages/unix-dirent/unix-dirent.0.1.0/opam
+++ b/packages/unix-dirent/unix-dirent.0.1.0/opam
@@ -1,15 +1,20 @@
-opam-version: "1"
-maintainer: "sheets@alum.mit.edu"
-authors: [
-  "David Sheets"
+opam-version: "1.2"
+maintainer:   "sheets@alum.mit.edu"
+authors:      ["David Sheets"]
+homepage:     "https://github.com/dsheets/ocaml-unix-dirent"
+bug-reports:  "https://github.com/dsheets/ocaml-unix-dirent/issues"
+dev-repo:     "https://github.com/dsheets/ocaml-unix-dirent.git"
+license:      "ISC"
+
+build: [make "build"]
+install: [make "install"]
+remove: [make "uninstall"]
+
+depends: [
+  "ocamlfind" {test}
+  "ctypes"    {<"0.4"}
+  "sexplib"
+  "type_conv"
+  "comparelib"
+  "bin_prot"
 ]
-homepage: "https://github.com/dsheets/ocaml-unix-dirent"
-license: "ISC"
-tags: [
-]
-build: [
-  [make "build"]
-  [make "install"]
-]
-remove: [[make "uninstall"]]
-depends: ["ocamlfind"]

--- a/packages/unix-dirent/unix-dirent.0.1.0/opam
+++ b/packages/unix-dirent/unix-dirent.0.1.0/opam
@@ -12,7 +12,7 @@ remove: [make "uninstall"]
 
 depends: [
   "ocamlfind" {test}
-  "ctypes"    {<"0.4"}
+  "ctypes"    {= "0.3.4"}
   "sexplib"
   "type_conv"
   "comparelib"


### PR DESCRIPTION
Cannot test it on OSX as it says:

```
#=== ERROR while installing unix-dirent.0.1.0 =================================#
# opam-version 1.2.2 (05903f71901dcc18c5f54e74ba07da71d67a9b2a)
# os           darwin
# command      make build
# path         /Users/thomas/.opam/profuse/build/unix-dirent.0.1.0
# compiler     system (4.02.1)
# exit-code    2
# env-file     /Users/thomas/.opam/profuse/build/unix-dirent.0.1.0/unix-dirent-59530-c743ac.env
# stdout-file  /Users/thomas/.opam/profuse/build/unix-dirent.0.1.0/unix-dirent-59530-c743ac.out
# stderr-file  /Users/thomas/.opam/profuse/build/unix-dirent.0.1.0/unix-dirent-59530-c743ac.err
### stdout ###
# ocamlfind ocamlc -o _build/lib/unix_dirent_private.cmi \
# [...]
# ocamlfind ocamlc -o _build/lib/unix_dirent_common.cmi \
# 		-syntax camlp4o -package ctypes.foreign -package sexplib.syntax -package comparelib.syntax -package bin_prot.syntax -c lib/unix_dirent_common.mli
# ocamlfind ocamlc -o _build/lib/unix_dirent.cmi -I _build/lib -I lib \
# 		-syntax camlp4o -package ctypes.foreign -package sexplib.syntax -package comparelib.syntax -package bin_prot.syntax -c lib/unix/unix_dirent.mli
# ocamlfind ocamlmklib -o _build/lib/unix_dirent -I _build/lib \
# 		-ocamlc   "ocamlfind ocamlc -syntax camlp4o -package ctypes.foreign -package sexplib.syntax -package comparelib.syntax -package bin_prot.syntax" \
# 		-ocamlopt "ocamlfind ocamlopt -syntax camlp4o -package ctypes.foreign -package sexplib.syntax -package comparelib.syntax -package bin_prot.syntax" \
# 		-package ctypes.foreign -package sexplib.syntax -package comparelib.syntax -package bin_prot.syntax lib/unix_dirent_private.ml lib/unix_dirent_common.ml \
# 		lib/unix/unix_dirent.ml _build/lib/unix/unix_dirent_stubs.o
### stderr ###
# >> Fatal error: Selection.emit_expr: unbound var addr_1353
# Fatal error: exception Misc.Fatal_error
# make: *** [build] Error 2
```

I'll try to run that on linux next.