### PR TITLE
afl instrumentation support for OCaml

### DIFF
--- a/compilers/4.02.3+afl.comp
+++ b/compilers/4.02.3+afl.comp
@@ -1,0 +1,15 @@
+opam-version: "1"
+version: "4.02.3+afl"
+src: "https://github.com/stedolan/ocaml/archive/fuzzing.tar.gz"
+build: [
+  ["./configure" "-prefix" prefix]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+  "base-ocamlbuild"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/compilers/4.02.3+afl.descr
+++ b/compilers/4.02.3+afl.descr
@@ -1,0 +1,1 @@
+OCaml 4.02.3, with support for american fuzzy lop


### PR DESCRIPTION
[american fuzzy lop](http://lcamtuf.coredump.cx/afl/) is a wonderful hammer for smashing one's favourite toys to bits, and this version of `ocamlopt` generates instrumentation support to help it wreak havoc.